### PR TITLE
A minimal std::expected<T, E>

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+---
+BasedOnStyle: Google
+---
+Language: Cpp
+DerivePointerAlignment: false
+PointerAlignment: Left

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright 2019 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     https://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+cmake_minimum_required(VERSION 3.13)
+
+enable_testing()
+find_package(GTest MODULE REQUIRED)
+
+# Include directories accessible from here.
+include_directories(.)
+
+# Require C++17 with no extensions.
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Add the test to the std::expected implementation.
+add_executable(expected_test netlib/expected_test.cc)
+target_link_libraries(expected_test PRIVATE GTest::GTest GTest::Main)
+add_test(expected_test expected_test)

--- a/netlib/README.md
+++ b/netlib/README.md
@@ -1,0 +1,29 @@
+# netlib Directory
+
+This is the main source directory for the project. The intent is to keep this
+directory flat with subdirectories for logical groupings. This means all the
+headers, implementation, and test code should be co-hosted in this directory.
+
+## Structure
+
+All implementation files must end with the `.cc` filename extension, and all
+headers must end in `.h`. If we have a file named `connection.cc` the header
+must be `connection.h` and the test(s) should be in `connection_test.cc`.
+
+We shall control the installed headers through our CMake configuration
+instead of assuming that all headers are publicly accessible. When including
+files, we should always include headers in the netlib repository by relative
+inclusion with the `netlib/` directory (based off the root of the
+repository). As an example:
+
+```c++
+// In connection.cc and connection_test.cc.
+#include "netlib/connection.h"
+```
+
+## Subdirectories
+
+We can introduce subdirectories for logical grouping, each one following the
+same structure rules as described here. For instance, if we have a
+subdirectory of encoding/decoding, we can introduce a `coding/` subdirectory
+with all the encoders and decoders implemented.

--- a/netlib/expected.h
+++ b/netlib/expected.h
@@ -1,0 +1,216 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef CPP_NETLIB_EXPECTED_H_
+#define CPP_NETLIB_EXPECTED_H_
+
+#include <type_traits>
+#include <utility>
+
+namespace cppnetlib {
+
+/// This is a minimal implementation of the proposed P0323R3
+/// std::unexpected<...> API.
+template <class E>
+// requires EqualityComparable<E> && (CopyConstructible<E> ||
+// MoveConstructible<E>)
+class unexpected {
+ public:
+  static_assert(!std::is_same_v<E, void>, "unexpected<void> is not supported.");
+
+  unexpected() = delete;
+  constexpr explicit unexpected(const E& e) : value_(e) {}
+  constexpr explicit unexpected(E&& e) : value_(std::move(e)) {}
+  constexpr const E& value() const& { return value_; }
+  constexpr E& value() & { return value_; }
+  constexpr E&& value() && { return std::move(value_); }
+  constexpr const E&& value() const&& { return std::move(value_); }
+
+  // This is a deviation from the proposal which suggests that these functions
+  // are namespace-level functions, instead of ADL-only found comparison
+  // operators (defined friend free functions).
+  template <class F>
+  friend constexpr bool operator==(const unexpected<F>& lhs,
+                                   const unexpected<F>& rhs) {
+    return lhs.value_ == rhs.value_;
+  }
+
+  template <class F>
+  friend constexpr bool operator!=(const unexpected<F>& lhs,
+                                   const unexpected<F>& rhs) {
+    return lhs.value_ == rhs.value_;
+  }
+
+ private:
+  E value_;
+};
+
+struct unexpect_t {
+  unexpect_t() = default;
+};
+inline constexpr unexpect_t unexpect{};
+
+template <class E>
+class bad_expected_access {};
+
+/// This is a minimal implementation of the proposed P0323R3
+/// std::expected<...> API.
+template <class T, class E>
+class expected {
+ public:
+  using value_type = T;
+  using error_type = E;
+  using unexpected_type = unexpected<E>;
+
+  template <class U>
+  struct rebind {
+    using type = expected<U, error_type>;
+  };
+
+  constexpr expected() : has_value_(false) {}
+  constexpr expected(const expected& other)
+      : union_storage_(other.union_storage_), has_value_(other.has_value_) {}
+
+  constexpr expected(
+      expected&& other,
+      std::enable_if_t<std::is_move_constructible_v<T> &&
+                       std::is_move_constructible_v<E>>* =
+          0) noexcept(std::is_nothrow_move_constructible_v<T>&&
+                          std::is_nothrow_move_constructible_v<E>)
+      : has_value_(other.has_value_) {
+    if (other.has_value_)
+      new (union_storage_)
+          T(std::move(*reinterpret_cast<T*>(other.union_storage_)));
+    else
+      new (union_storage_)
+          unexpected<E>(std::move(*reinterpret_cast<E*>(other.union_storage_)));
+  }
+
+ private:
+  template <class U, class G>
+  using constructor_helper_t =
+      std::enable_if_t<std::is_constructible_v<T, const U&> and
+                       std::is_constructible_v<E, const G&> and
+                       !std::is_constructible_v<T, expected<U, G>&> and
+                       !std::is_constructible_v<T, expected<U, G>&&> and
+                       !std::is_constructible_v<T, const expected<U, G>&> and
+                       !std::is_constructible_v<T, const expected<U, G>&&> and
+                       !std::is_convertible_v<expected<U, G>&, T> and
+                       !std::is_convertible_v<expected<U, G>&&, T> and
+                       !std::is_convertible_v<const expected<U, G>&, T> and
+                       !std::is_convertible_v<const expected<U, G>&&, T>>;
+
+ public:
+  // TODO: c++20 has support for conditional explicit, use that instead of the
+  // duplication.
+  template <class U, class G,
+            std::enable_if_t<!(std::is_convertible_v<const U&, T> and
+                               std::is_convertible_v<const G&, E>),
+                             bool> = false>
+  explicit constexpr expected(const expected<U, G>& other,
+                              constructor_helper_t<U, G>* = 0)
+      : has_value_(other.has_value_) {
+    if (other.has_value_)
+      new (&union_storage_) T(*other);
+    else
+      new (&union_storage_) unexpected<E>(other.error());
+  }
+
+  template <class U, class G,
+            std::enable_if_t<(std::is_convertible_v<const U&, T> and
+                              std::is_convertible_v<const G&, E>),
+                             bool> = false>
+  constexpr expected(const expected<U, G>& other,
+                     constructor_helper_t<U, G>* = 0)
+      : has_value_(other.has_value_) {
+    if (other.has_value_)
+      new (&union_storage_) T(*other);
+    else
+      new (&union_storage_) unexpected<E>(other.error());
+  }
+
+  template <class U, class G,
+            std::enable_if_t<!(std::is_convertible_v<const U&, T> and
+                               std::is_convertible_v<const G&, E>),
+                             bool> = false>
+  explicit constexpr expected(const expected<U, G>&& other,
+                              constructor_helper_t<U, G>* = 0)
+      : has_value_(other.has_value_) {
+    if (other.has_value_)
+      new (&union_storage_) T(std::move(*other));
+    else
+      new (&union_storage_) unexpected<E>(std::move(unexpected(other.error())));
+  }
+
+  template <class U = T,
+            std::enable_if_t<!std::is_convertible_v<U&&, T>, bool> = false>
+  explicit constexpr expected(
+      U&& value,
+      std::enable_if_t<std::is_constructible_v<T, U&&> and
+                       !std::is_same_v<std::decay_t<U>, std::in_place_t> and
+                       !std::is_same_v<expected<T, E>, std::decay_t<U>> and
+                       !std::is_same_v<unexpected<E>, std::decay_t<U>>>* = 0)
+      : has_value_(true) {
+    new (&union_storage_) U(std::forward<U>(std::move(value)));
+  }
+
+  template <class U = T,
+            std::enable_if_t<std::is_convertible_v<U&&, T>, bool> = false>
+  constexpr expected(
+      U&& value,
+      std::enable_if_t<std::is_constructible_v<T, U&&> and
+                       !std::is_same_v<std::decay_t<U>, std::in_place_t> and
+                       !std::is_same_v<expected<T, E>, std::decay_t<U>> and
+                       !std::is_same_v<unexpected<E>, std::decay_t<U>>>* = 0)
+      : has_value_(true) {
+    new (&union_storage_) U(std::forward<U>(value));
+  }
+
+  template <class G = E,
+            std::enable_if_t<!std::is_convertible_v<const G&, E>, bool> = false>
+  explicit constexpr expected(unexpected<G> const& e) : has_value_(false) {
+    new (&union_storage_) unexpected<E>(e);
+  }
+
+  template <class G = E,
+            std::enable_if_t<std::is_convertible_v<const G&, E>, bool> = false>
+  constexpr expected(unexpected<G> const& e) : has_value_(false) {
+    new (&union_storage_) unexpected<E>(e);
+  }
+
+  template <class G = E,
+            std::enable_if_t<!std::is_convertible_v<G&&, E>, bool> = false>
+  explicit constexpr expected(unexpected<G>&& e) noexcept(
+      std::is_nothrow_move_constructible_v<E, G&&>)
+      : has_value_(false) {
+    new (&union_storage_) unexpected<E>(std::move(e.value()));
+  }
+
+  template <class G = E,
+            std::enable_if_t<std::is_convertible_v<G&&, E>, bool> = false>
+  constexpr expected(unexpected<G>&& e) noexcept(
+      std::is_nothrow_constructible_v<E, G&&>)
+      : has_value_(false) {
+    new (&union_storage_) unexpected<E>(std::move(e.value()));
+  }
+
+  constexpr explicit operator bool() const noexcept { return has_value_; }
+
+ private:
+  std::aligned_union_t<8, value_type, unexpected_type> union_storage_;
+  bool has_value_;
+};
+
+}  // namespace cppnetlib
+
+#endif  // CPP_NETLIB_EXPECTED_H_

--- a/netlib/expected.h
+++ b/netlib/expected.h
@@ -14,6 +14,7 @@
 #ifndef CPP_NETLIB_EXPECTED_H_
 #define CPP_NETLIB_EXPECTED_H_
 
+#include <cassert>
 #include <type_traits>
 #include <utility>
 
@@ -205,6 +206,33 @@ class expected {
   }
 
   constexpr explicit operator bool() const noexcept { return has_value_; }
+
+  // Observer functions.
+  constexpr const E& error() const& {
+    assert(!has_value_ &&
+           "expected<T, E> must not have a value when taking an error!");
+    return reinterpret_cast<const unexpected<E>*>(&union_storage_)->value();
+  }
+
+  constexpr E& error() & {
+    assert(!has_value_ &&
+           "expected<T, E> must not have a value when taking an error!");
+    return reinterpret_cast<unexpected<E>*>(&union_storage_)->value();
+  }
+
+  constexpr const E&& error() const&& {
+    assert(!has_value_ &&
+           "expected<T, E> must not have a value when taking an error!");
+    return std::move(*reinterpret_cast<const unexpected<E>*>(&union_storage_))
+        ->value();
+  }
+
+  constexpr E&& error() && {
+    assert(!has_value_ &&
+           "expected<T, E> must not have a value when taking an error!");
+    return std::move(*reinterpret_cast<unexpected<E>*>(&union_storage_))
+        ->value();
+  };
 
  private:
   std::aligned_union_t<8, value_type, unexpected_type> union_storage_;

--- a/netlib/expected_test.cc
+++ b/netlib/expected_test.cc
@@ -18,6 +18,8 @@
 namespace cppnetlib {
 namespace {
 
+using ::testing::Eq;
+
 using error_code = int;
 
 enum errors : error_code { undefined };
@@ -27,13 +29,29 @@ expected<bool, error_code> f(bool b) {
   return unexpected(errors::undefined);
 }
 
+// For testing support for larger types.
+struct test_data {
+  int64_t first;
+  int64_t second;
+};
+
+expected<test_data, error_code> g(bool b, int64_t first, int64_t second) {
+  if (b) return unexpected{errors::undefined};
+  return test_data{first, second};
+}
+
 TEST(ExpectedTest, Construction) { expected<bool, error_code> e; }
 
 TEST(ExpectedTest, Unexpected) {
-  auto e = f(true);
-  auto g = f(false);
-  ASSERT_FALSE(g);
-  ASSERT_TRUE(e);
+  auto e1 = f(true);
+  ASSERT_TRUE(e1);
+
+  auto e2 = f(false);
+  ASSERT_FALSE(e2);
+
+  auto e3 = g(true, 1, 2);
+  ASSERT_FALSE(e2);
+  EXPECT_THAT(e3.error(), Eq(errors::undefined));
 }
 
 }  // namespace

--- a/netlib/expected_test.cc
+++ b/netlib/expected_test.cc
@@ -48,6 +48,7 @@ TEST(ExpectedTest, Unexpected) {
 
   auto e2 = f(false);
   ASSERT_FALSE(e2);
+  ASSERT_THROW(*e2, bad_expected_access<error_code>);
 
   auto e3 = g(true, 1, 2);
   ASSERT_FALSE(e2);

--- a/netlib/expected_test.cc
+++ b/netlib/expected_test.cc
@@ -1,0 +1,40 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "netlib/expected.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace cppnetlib {
+namespace {
+
+using error_code = int;
+
+enum errors : error_code { undefined };
+
+expected<bool, error_code> f(bool b) {
+  if (b) return true;
+  return unexpected(errors::undefined);
+}
+
+TEST(ExpectedTest, Construction) { expected<bool, error_code> e; }
+
+TEST(ExpectedTest, Unexpected) {
+  auto e = f(true);
+  auto g = f(false);
+  ASSERT_FALSE(g);
+  ASSERT_TRUE(e);
+}
+
+}  // namespace
+}  // namespace cppnetlib

--- a/netlib/expected_test.cc
+++ b/netlib/expected_test.cc
@@ -51,8 +51,14 @@ TEST(ExpectedTest, Unexpected) {
   ASSERT_THROW(*e2, bad_expected_access<error_code>);
 
   auto e3 = g(true, 1, 2);
-  ASSERT_FALSE(e2);
+  ASSERT_FALSE(e3);
   EXPECT_THAT(e3.error(), Eq(errors::undefined));
+  ASSERT_THROW(*e3, bad_expected_access<error_code>);
+
+  e3 = g(false, 2, 3);
+  ASSERT_TRUE(e3);
+  ASSERT_THAT(e3->first, Eq(2));
+  ASSERT_THAT(e3->second, Eq(3));
 }
 
 }  // namespace


### PR DESCRIPTION
This change includes a minimal implementation of the std::expected<T, E>
proposal in P0323R3 (http://wg21.link/P0323R3) which is hosted in the
`cppnetlib` namespace.

In the process we also document some of our guidelines on the structure
of the repository, on naming files, directory structure, and dependency
requirements.

Still TODO:

* Update documentation on using vcpkg on dependencies.
* Work our way up to a minimal interface for a connecton type, using our
  std::expected utility type.

This is related to the work in cpp-netlib/netlib#5 for implementing a minimal
connection type suitable as a building block for higher level protocol
implementations.